### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
+++ b/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
@@ -199,10 +199,13 @@ class RoboMaintenance:
         """
 
         sanitized_model_path = secure_filename(model_path)
-        normalized_model_path = os.path.normpath(sanitized_model_path)
-        self.scaler_path = os.path.join(SAFE_BASE_DIR, normalized_model_path, self.model_name + "_scaler.joblib")
-        real_scaler_path = os.path.realpath(self.scaler_path)
-        if not real_scaler_path.startswith(os.path.realpath(SAFE_BASE_DIR) + os.sep):
+        self.scaler_path = os.path.normpath(
+            os.path.join(
+                SAFE_BASE_DIR, sanitized_model_path, self.model_name + "_scaler.joblib"
+            )
+        )
+        self.scaler_path = os.path.abspath(self.scaler_path)
+        if not self.scaler_path.startswith(os.path.abspath(SAFE_BASE_DIR) + os.sep):
             raise ValueError("Path is not within the allowed model directory.")
 
         logger.info("Saving Scaler")

--- a/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
+++ b/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
@@ -201,11 +201,12 @@ class RoboMaintenance:
         sanitized_model_path = secure_filename(model_path)
         normalized_model_path = os.path.normpath(sanitized_model_path)
         self.scaler_path = os.path.join(SAFE_BASE_DIR, normalized_model_path, self.model_name + "_scaler.joblib")
-        if not os.path.commonpath([os.path.realpath(self.scaler_path), os.path.realpath(SAFE_BASE_DIR)]) == os.path.realpath(SAFE_BASE_DIR):
+        real_scaler_path = os.path.realpath(self.scaler_path)
+        if not real_scaler_path.startswith(os.path.realpath(SAFE_BASE_DIR) + os.sep):
             raise ValueError("Path is not within the allowed model directory.")
 
         logger.info("Saving Scaler")
-        with open(self.scaler_path, "wb") as fh:
+        with open(real_scaler_path, "wb") as fh:
             joblib.dump(self.robust_scaler, fh.name)
 
         logger.info("Saving Scaler as MLFLow Artifact")

--- a/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
+++ b/MLOps_Professional/mlops_capstone/robot_maintenance/src/train.py
@@ -209,7 +209,7 @@ class RoboMaintenance:
             raise ValueError("Path is not within the allowed model directory.")
 
         logger.info("Saving Scaler")
-        with open(real_scaler_path, "wb") as fh:
+        with open(self.scaler_path, "wb") as fh:
             joblib.dump(self.robust_scaler, fh.name)
 
         logger.info("Saving Scaler as MLFLow Artifact")


### PR DESCRIPTION
Potential fix for [https://github.com/lgurav/certified-developer/security/code-scanning/13](https://github.com/lgurav/certified-developer/security/code-scanning/13)

To fix the problem, we need to ensure that the constructed file path is strictly within the `SAFE_BASE_DIR` directory. This can be achieved by normalizing the path and then checking that the normalized path starts with the `SAFE_BASE_DIR` directory. We will also ensure that the `model_path` does not contain any special characters that could lead to directory traversal.

1. Normalize the `model_path` using `os.path.normpath`.
2. Join the normalized `model_path` with `SAFE_BASE_DIR`.
3. Check that the resulting path starts with `SAFE_BASE_DIR`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
